### PR TITLE
feat: integrate OpenAI for lesson generation

### DIFF
--- a/agents/lesson_generator.py
+++ b/agents/lesson_generator.py
@@ -1,23 +1,34 @@
 # // file: skillence_ai/agents/lesson_generator.py
 
 """
-Agent 'lesson_generator' (stub) — Pydantic partout.
+Agent 'lesson_generator' — génération via API OpenAI.
 
 Rôle:
 - Définir les modèles d'entrée/sortie (Pydantic v2) pour la génération de leçon.
-- Fournir une fonction `generate_lesson` qui produit un plan + contenu (mock).
-- Servira d'interface stable avant intégration LLM (Semaine 2 : tool calling).
+- Fournir une fonction `generate_lesson` qui s'appuie sur OpenAI Chat Completions.
 
 Contraintes:
 - Python 3.11+, Pydantic v2.
-- Pas d'appel externe ici (pas de secrets).
+- Appel externe avec timeout et limite de tokens.
 """
 
 # Inventaire des dépendances
-# - typing (stdlib) : types statiques (List) — alternative: collections.abc pour Sequence
-# - pydantic (tierce) : modèles de validation/sérialisation (BaseModel v2)
-from typing import List  # stdlib — typing statique pour les listes
-from pydantic import BaseModel, Field  # tierce — data models/validation (vs dataclasses sans validation)
+# - typing (stdlib) : types statiques (List)
+# - json (stdlib)   : parse la réponse OpenAI
+# - httpx (tierce)  : timeout pour l'appel OpenAI
+# - fastapi (tierce) : HTTPException pour les erreurs API
+# - openai (tierce) : client OpenAI 2025
+# - pydantic (tierce) : modèles de validation
+from typing import List
+import json
+
+import httpx
+from fastapi import HTTPException
+from openai import OpenAI
+from pydantic import BaseModel, Field
+from storage.base import settings
+
+client = OpenAI(api_key=settings.OPENAI_API_KEY, timeout=httpx.Timeout(15.0))
 
 
 class LessonRequest(BaseModel):
@@ -36,30 +47,24 @@ class LessonContent(BaseModel):
 
 
 def generate_lesson(request: LessonRequest) -> LessonContent:
-    """
-    Génère une leçon vulgarisée (stub synchrone).
-    Remplacé plus tard par un appel LLM avec timeouts et limites de tokens.
-    """
-    # NB: on adapte légèrement selon la durée pour montrer la future variabilité
-    if request.duration == "short":
-        plan = ["Introduction", "Points clés", "Conclusion"]
-        words_hint = "~300 mots"
-    elif request.duration == "medium":
-        plan = ["Introduction", "Développement", "Exemples", "Conclusion"]
-        words_hint = "~600 mots"
-    else:
-        plan = ["Introduction", "Contexte", "Développement", "Études de cas", "Conclusion"]
-        words_hint = "~900 mots"
-
-    return LessonContent(
-        title=f"{request.subject} (niveau {request.audience})",
-        objectives=[
-            "Comprendre les bases du sujet",
-            "Identifier les étapes clés",
-        ],
-        plan=plan,
-        content=(
-            f"Explication vulgarisée de {request.subject}, adaptée pour un public {request.audience}. "
-            f"Cette version {request.duration} vise {words_hint} et reste factuellement simple (MVP)."
-        ),
+    """Génère une leçon via l'API OpenAI."""
+    prompt = (
+        "Tu es un assistant pédagogique. Réponds avec un JSON contenant les clés "
+        "'title', 'objectives', 'plan', 'content'.\n"
+        f"Sujet: {request.subject}\nAudience: {request.audience}\nDurée: {request.duration}"
     )
+    try:
+        resp = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=2000,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="OpenAI API call failed") from exc
+
+    try:
+        data = json.loads(resp.choices[0].message.content)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Invalid OpenAI response") from exc
+
+    return LessonContent(**data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ httpx>=0.27
 pytest>=8
 pytest-asyncio>=0.23
 pydantic-settings>=2,<3
+openai>=1.0.0

--- a/storage/base.py
+++ b/storage/base.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
 
     # Par défaut : un fichier SQLite local. Pratique pour démarrer sans rien installer.
     DATABASE_URL: str = "sqlite:///./skillence_ai.db"
+    OPENAI_API_KEY: str = ""
 
     class Config:
         # On lit un fichier `.env` si présent, pour surcharger cette valeur

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_openai(monkeypatch):
+    """Mocke l'appel OpenAI pour des tests déterministes."""
+    def fake_create(*args, **kwargs):
+        messages = kwargs.get("messages", [])
+        content = messages[0]["content"] if messages else ""
+        subject = audience = ""
+        for line in content.splitlines():
+            if line.startswith("Sujet:"):
+                subject = line.split(":", 1)[1].strip()
+            if line.startswith("Audience:"):
+                audience = line.split(":", 1)[1].strip()
+        payload = {
+            "title": f"{subject} (niveau {audience})",
+            "objectives": ["Obj1", "Obj2"],
+            "plan": ["Introduction", "Développement", "Conclusion"],
+            "content": f"Contenu sur {subject} pour {audience}"
+        }
+        data = json.dumps(payload)
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=data))])
+
+    monkeypatch.setattr(
+        "agents.lesson_generator.client.chat.completions.create",
+        fake_create,
+    )


### PR DESCRIPTION
## Summary
- replace stubbed lesson generation with OpenAI Chat Completions
- load OpenAI key from settings and expose timeout controls
- mock OpenAI in tests for deterministic behaviour

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68c5cbd3cf3c8325b9d07134babf7130