### PR TITLE
feat: add optional OpenAI API key setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ pip install -r requirements.txt
 ```
 
 ### Configuration
+Créez un fichier `.env` et ajoutez votre clé :
+
 ```bash
-cp .env.example .env
-# Ajoutez votre clé OpenAI
-OPENAI_API_KEY=sk-...
+echo "OPENAI_API_KEY=sk-..." > .env
 ```
 
 ### Lancer le serveur

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "sqlalchemy>=2.0",
   "pydantic-settings>=2,<3",
   "httpx>=0.27,<0.28",  # pin pour compatibilité avec tests (AsyncClient(app=...))
+  "openai>=1.0.0",
 ]
 
 [build-system]

--- a/storage/base.py
+++ b/storage/base.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
 
     # Par défaut : un fichier SQLite local. Pratique pour démarrer sans rien installer.
     DATABASE_URL: str = "sqlite:///./skillence_ai.db"
-    OPENAI_API_KEY: str = ""
+    OPENAI_API_KEY: str | None = None
 
     class Config:
         # On lit un fichier `.env` si présent, pour surcharger cette valeur


### PR DESCRIPTION
## Summary
- allow disabling OpenAI by making API key optional in Settings
- document how to provide `OPENAI_API_KEY` via `.env`
- declare OpenAI client dependency in `pyproject.toml`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai>=1.0.0)*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68c5d3967ee0832583c0187af997d7d9