### PR TITLE
feat: add readability summary to formatted lessons

### DIFF
--- a/agents/formatter.py
+++ b/agents/formatter.py
@@ -10,14 +10,20 @@ NETTOYAGE v0.1.2:
 # Inventaire des dépendances
 # - pydantic (tierce) : modèles de validation v2 — BaseModel pour structure
 # - agents.lesson_generator (local) : DTO d'entrée LessonContent — contenu à formater
+# - agents.quality_utils (local) : validation et résumé lisibilité
 from pydantic import BaseModel
 from .lesson_generator import LessonContent
+from .quality_utils import (
+    validate_readability_for_audience,
+    get_readability_summary,
+)
 
 
 class LessonFormatted(BaseModel):
     """Résultat final du formatter (SIMPLIFIÉ - sans quiz)."""
     title: str
     markdown: str
+    readability: dict
     # SUPPRIMÉ: quiz field
 
 
@@ -56,8 +62,13 @@ def format_lesson(content: LessonContent) -> LessonFormatted:
         Markdown formaté prêt à l'export
     """
     markdown = _build_markdown(content)
-    
+
+    # Analyse de lisibilité pour audience par défaut 'lycéen'
+    score = validate_readability_for_audience(markdown, "lycéen")
+    readability = get_readability_summary(score)
+
     return LessonFormatted(
-        title=content.title, 
-        markdown=markdown
+        title=content.title,
+        markdown=markdown,
+        readability=readability,
     )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -42,6 +42,9 @@ def test_format_lesson_creates_structured_markdown():
     
     # Vérifications modèle
     assert formatted.title == "La photosynthèse expliquée"
+    assert isinstance(formatted.readability, dict)
+    assert formatted.readability["audience_target"] == "lycéen"
+    assert "flesch_kincaid_score" in formatted.readability
     
     # SUPPRIMÉ: Vérifications quiz
 
@@ -66,3 +69,7 @@ def test_format_lesson_handles_minimal_content():
     assert "1. Section A" in formatted.markdown
     assert "2. Section B" in formatted.markdown
     assert "Contenu court." in formatted.markdown
+
+    # Lisibilité disponible même pour contenu minimal
+    assert isinstance(formatted.readability, dict)
+    assert "readability_level" in formatted.readability


### PR DESCRIPTION
## Summary
- extend formatted lesson model with readability report
- compute readability analysis in lesson formatter
- cover formatter readability output in tests

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c70b450f80832590d23b231bd91b6e