### PR TITLE
feat: validate lesson readability

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,13 +13,13 @@ NETTOYAGE v0.1.2:
 # - pydantic (tierce) : modèles de réponse API — validation I/O
 # - typing (stdlib) : annotations de types — améliore lisibilité
 # - agents.lesson_generator (local) : DTO d'entrée — modèle de requête
-# - api.services.lessons (local) : orchestration métier — logique principale  
+# - api.services.lessons (local) : orchestration métier — logique principale
 # - api.middleware.logging (local) : middleware de logs — corrélation requêtes
 # - storage.base (local) : initialisation DB — setup base de données
 import logging
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from agents.lesson_generator import LessonRequest
 from api.services.lessons import create_lesson, get_lesson_by_id
@@ -42,6 +42,7 @@ class LessonResponse(BaseModel):
     lesson_id: str
     title: str
     message: str
+    readability: Dict[str, Any]
     from_cache: Optional[bool] = False
 
 
@@ -94,7 +95,8 @@ def create_lesson_endpoint(payload: LessonRequest) -> LessonResponse:
             lesson_id=result["lesson_id"],
             title=result["title"],
             message="Leçon pédagogique générée avec succès",
-            from_cache=result.get("from_cache", False)
+            readability=result["readability"],
+            from_cache=result.get("from_cache", False),
         )
         
     except Exception as exc:

--- a/tests/test_api_lessons.py
+++ b/tests/test_api_lessons.py
@@ -94,6 +94,9 @@ async def test_create_lesson_happy_path_isolated(test_app_with_isolated_db):
         assert len(data["lesson_id"]) == 36  # UUID
         assert data["title"] == "Test isolation complète (niveau lycéen)"
         assert data["from_cache"] is False
+        assert "readability" in data
+        assert data["readability"]["audience_target"] == "lycéen"
+        assert isinstance(data["readability"]["is_appropriate_for_audience"], bool)
         
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- validate lesson markdown against request audience and warn on mismatch
- expose readability metrics in create lesson API response
- check returned readability metadata in API integration test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c70c68d720832581d95dcb796b3996