### PR TITLE
feat: wrap readability in quality summary

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -38,11 +38,14 @@ logger = logging.getLogger("skillence_ai.main")
 
 # Modèles de réponse API (SANS QUIZ)
 class LessonResponse(BaseModel):
-    """Réponse POST /v1/lessons (création) - SIMPLIFIÉ."""
+    """Réponse POST /v1/lessons (création) - SIMPLIFIÉ.
+
+    Inclut les métriques de qualité (ex: lisibilité) sous ``quality``.
+    """
     lesson_id: str
     title: str
     message: str
-    readability: Dict[str, Any]
+    quality: Dict[str, Any]
     from_cache: Optional[bool] = False
 
 
@@ -86,7 +89,7 @@ def health() -> Dict[str, str]:
 def create_lesson_endpoint(payload: LessonRequest) -> LessonResponse:
     """
     Crée une leçon pédagogique de qualité (plan + contenu vulgarisé).
-    FOCUS v0.1: Excellence du contenu explicatif.
+    Retourne les métadonnées de leçon et un résumé ``quality`` (ex: lisibilité).
     """
     try:
         result = create_lesson(payload)
@@ -95,7 +98,7 @@ def create_lesson_endpoint(payload: LessonRequest) -> LessonResponse:
             lesson_id=result["lesson_id"],
             title=result["title"],
             message="Leçon pédagogique générée avec succès",
-            readability=result["readability"],
+            quality=result["quality"],
             from_cache=result.get("from_cache", False),
         )
         

--- a/api/services/lessons.py
+++ b/api/services/lessons.py
@@ -54,7 +54,8 @@ def _compute_request_hash(request: LessonRequest) -> str:
 def create_lesson(request: LessonRequest) -> Dict[str, Any]:
     """
     Orchestre génération + formatage + persistance (SANS QUIZ).
-    Ajoute validation de lisibilité selon l'audience.
+    Ajoute validation de lisibilité selon l'audience et retourne
+    un dictionnaire avec métadonnées et métriques ``quality``.
     """
     start_time = time.time()
 
@@ -81,11 +82,12 @@ def create_lesson(request: LessonRequest) -> Dict[str, Any]:
                     f"score={cached_score.flesch_kincaid:.1f}"
                 )
 
+            # Résumé lisibilité exposé via "quality"
             return {
                 "lesson_id": existing.lessons[0].id,
                 "title": existing.lessons[0].title,
                 "from_cache": True,
-                "readability": cached_summary,
+                "quality": {"readability": cached_summary},
             }
 
     # 2. Génération de contenu (focus qualité)
@@ -146,11 +148,12 @@ def create_lesson(request: LessonRequest) -> Dict[str, Any]:
         log_operation("lesson_creation_completed", total_duration,
                       from_cache=False)
 
+        # Inclut les métriques de lisibilité dans "quality"
         return {
             "lesson_id": db_lesson.id,
             "title": db_lesson.title,
             "from_cache": False,
-            "readability": readability_summary,
+            "quality": {"readability": readability_summary},
         }
 
 

--- a/tests/test_api_lessons.py
+++ b/tests/test_api_lessons.py
@@ -94,9 +94,12 @@ async def test_create_lesson_happy_path_isolated(test_app_with_isolated_db):
         assert len(data["lesson_id"]) == 36  # UUID
         assert data["title"] == "Test isolation complète (niveau lycéen)"
         assert data["from_cache"] is False
-        assert "readability" in data
-        assert data["readability"]["audience_target"] == "lycéen"
-        assert isinstance(data["readability"]["is_appropriate_for_audience"], bool)
+        assert "quality" in data
+        assert "readability" in data["quality"]
+        assert data["quality"]["readability"]["audience_target"] == "lycéen"
+        assert isinstance(
+            data["quality"]["readability"]["is_appropriate_for_audience"], bool
+        )
         
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- wrap readability metrics under `quality` in the lesson response
- adapt service layer to return `quality` block instead of top-level `readability`
- update tests for `quality["readability"]`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7126e0ee083258ac9a1cf47418417