### PR TITLE
feat: expose readability metrics on lesson detail

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -50,7 +50,7 @@ class LessonResponse(BaseModel):
 
 
 class LessonDetailResponse(BaseModel):
-    """Réponse GET /v1/lessons/{id} (détail complet) - SANS QUIZ."""
+    """Réponse GET /v1/lessons/{id} (détail complet) avec métriques."""
     id: str
     title: str
     content: str
@@ -58,6 +58,7 @@ class LessonDetailResponse(BaseModel):
     plan: list[str]
     # SUPPRIMÉ: quiz: list[dict]
     created_at: str
+    quality: Dict[str, Any]
 
 
 # Application FastAPI avec middleware de logs
@@ -113,7 +114,7 @@ def create_lesson_endpoint(payload: LessonRequest) -> LessonResponse:
 @app.get("/v1/lessons/{lesson_id}", response_model=LessonDetailResponse)
 def get_lesson_endpoint(lesson_id: str) -> LessonDetailResponse:
     """
-    Récupère une leçon existante par son ID (contenu + métadonnées).
+    Récupère une leçon existante par son ID (contenu, métadonnées et métriques).
     """
     try:
         lesson_data = get_lesson_by_id(lesson_id)

--- a/tests/test_api_lessons.py
+++ b/tests/test_api_lessons.py
@@ -100,6 +100,34 @@ async def test_create_lesson_happy_path_isolated(test_app_with_isolated_db):
         assert isinstance(
             data["quality"]["readability"]["is_appropriate_for_audience"], bool
         )
+
+
+@pytest.mark.asyncio
+async def test_get_lesson_includes_quality_metrics(test_app_with_isolated_db):
+    """Récupération d'une leçon avec métriques de lisibilité."""
+    transport = ASGITransport(app=test_app_with_isolated_db)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = {
+            "subject": "Test GET qualité",
+            "audience": "lycéen",
+            "duration": "short",
+        }
+
+        create_resp = await client.post("/v1/lessons", json=payload)
+        lesson_id = create_resp.json()["lesson_id"]
+
+        get_resp = await client.get(f"/v1/lessons/{lesson_id}")
+
+        assert get_resp.status_code == 200
+        data = get_resp.json()
+        assert data["id"] == lesson_id
+        assert "quality" in data
+        assert "readability" in data["quality"]
+        assert data["quality"]["readability"]["audience_target"] == "lycéen"
+        assert isinstance(
+            data["quality"]["readability"]["is_appropriate_for_audience"], bool
+        )
         
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- compute readability metrics when fetching a lesson by ID
- extend API responses to return readability metrics
- cover GET /v1/lessons/{id} with new test verifying metrics

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71626ff2c83258ab57c28020435f5