### PR TITLE
feat: pass audience to formatter

### DIFF
--- a/agents/formatter.py
+++ b/agents/formatter.py
@@ -51,20 +51,21 @@ def _build_markdown(content: LessonContent) -> str:
     return "\n".join(lines)
 
 
-def format_lesson(content: LessonContent) -> LessonFormatted:
+def format_lesson(content: LessonContent, audience: str) -> LessonFormatted:
     """
     Construit un Markdown pédagogique structuré (FOCUS v0.1).
-    
+
     Args:
         content: Contenu généré par lesson_generator
-        
+        audience: Public cible servant à évaluer la lisibilité
+
     Returns:
         Markdown formaté prêt à l'export
     """
     markdown = _build_markdown(content)
 
-    # Analyse de lisibilité pour audience par défaut 'lycéen'
-    score = validate_readability_for_audience(markdown, "lycéen")
+    # Analyse de lisibilité adaptée à l'audience fournie
+    score = validate_readability_for_audience(markdown, audience)
     readability = get_readability_summary(score)
 
     return LessonFormatted(

--- a/api/services/lessons.py
+++ b/api/services/lessons.py
@@ -96,7 +96,7 @@ def create_lesson(request: LessonRequest) -> Dict[str, Any]:
                   subject=request.subject, audience=request.audience)
 
     lesson_content = generate_lesson(request)
-    formatted = format_lesson(lesson_content)  # SIMPLIFIÉ: plus de paramètre quiz
+    formatted = format_lesson(lesson_content, request.audience)  # audience pour lisibilité
 
     # Validation lisibilité selon audience requête
     readability_score = validate_readability_for_audience(

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -24,7 +24,7 @@ def test_format_lesson_creates_structured_markdown():
         content="La photosynthèse est un processus vital...",
     )
 
-    formatted = format_lesson(content)
+    formatted = format_lesson(content, "lycéen")
 
     # Vérifications structure Markdown
     assert formatted.markdown.startswith("# La photosynthèse expliquée")
@@ -60,7 +60,7 @@ def test_format_lesson_handles_minimal_content():
         content="Contenu court.",
     )
 
-    formatted = format_lesson(content)
+    formatted = format_lesson(content, "lycéen")
     
     # Structure présente même avec contenu minimal
     assert "# Test minimal" in formatted.markdown


### PR DESCRIPTION
## Summary
- allow formatter to accept explicit audience and forward it to readability checks
- adapt service and unit tests to supply audience information

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71d153e488325af49bd9dd6cf2eae