### PR TITLE
Expose token usage in lesson creation responses

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -40,12 +40,14 @@ logger = logging.getLogger("skillence_ai.main")
 class LessonResponse(BaseModel):
     """Réponse POST /v1/lessons (création) - SIMPLIFIÉ.
 
-    Inclut les métriques de qualité (ex: lisibilité) sous ``quality``.
+    Inclut les métriques de qualité (ex: lisibilité) sous ``quality``
+    ainsi que les ``tokens_used``.
     """
     lesson_id: str
     title: str
     message: str
     quality: Dict[str, Any]
+    tokens_used: int
     from_cache: Optional[bool] = False
 
 
@@ -94,12 +96,13 @@ def create_lesson_endpoint(payload: LessonRequest) -> LessonResponse:
     """
     try:
         result = create_lesson(payload)
-        
+
         return LessonResponse(
             lesson_id=result["lesson_id"],
             title=result["title"],
             message="Leçon pédagogique générée avec succès",
             quality=result["quality"],
+             tokens_used=result["tokens_used"],
             from_cache=result.get("from_cache", False),
         )
         

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,8 @@ def mock_openai_client():
         response.choices = [SimpleNamespace()]
         response.choices[0].message = SimpleNamespace()
         response.choices[0].message.content = json.dumps(payload)
-        
+        response.usage = SimpleNamespace(total_tokens=123)
+
         return response
 
     with patch('agents.lesson_generator.client.chat.completions.create', side_effect=fake_create):

--- a/tests/test_api_lessons.py
+++ b/tests/test_api_lessons.py
@@ -94,6 +94,7 @@ async def test_create_lesson_happy_path_isolated(test_app_with_isolated_db):
         assert len(data["lesson_id"]) == 36  # UUID
         assert data["title"] == "Test isolation complète (niveau lycéen)"
         assert data["from_cache"] is False
+        assert data["tokens_used"] == 123
         assert "quality" in data
         assert "readability" in data["quality"]
         assert data["quality"]["readability"]["audience_target"] == "lycéen"


### PR DESCRIPTION
## Summary
- Track `resp.usage.total_tokens` in lesson generation
- Log `tokens_used` and include it in service and API responses
- Extend tests to cover token propagation end-to-end

## Testing
- `PYTHONPATH=/workspace/skillence_ai pytest tests/test_api_lessons.py tests/test_lesson_generator.py -q`
- `PYTHONPATH=/workspace/skillence_ai pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72399b4b48325978dcf06ae5c83ec